### PR TITLE
Fix character encoding in email subject

### DIFF
--- a/src/PHPMailerAdapter.php
+++ b/src/PHPMailerAdapter.php
@@ -40,6 +40,8 @@ class PHPMailerAdapter implements MailerInterface {
 
             // Content
             $mail->isHTML(true);
+            $mail->CharSet = 'UTF-8';
+            $mail->Encoding = 'base64';
             $mail->Subject = $subject;
             $mail->Body    = $body;
 


### PR DESCRIPTION
When the post title contains Japanese characters like つなぎ融資 then it shows up like ã ¤ã ªã Žèž è³‡ in the email subject. This change should fix this issue.